### PR TITLE
Add mobile touch slicing support

### DIFF
--- a/jquery.js
+++ b/jquery.js
@@ -53,7 +53,26 @@ $(function(){
     });
 });
 
-$("#fruit").mouseover(cut);
+// support both mouse and touch interactions for slicing the fruit
+$("#fruit").on("mouseover touchstart", cut);
+
+// Detect pointer or touch movement across the container and slice the fruit
+$("#container").on("mousemove touchmove", function(event) {
+    const x = event.pageX || event.touches?.[0]?.pageX;
+    const y = event.pageY || event.touches?.[0]?.pageY;
+    const fruit = $("#fruit");
+
+    if (fruit.is(":visible")) {
+        const offset = fruit.offset();
+        const w = fruit.width();
+        const h = fruit.height();
+
+        if (x >= offset.left && x <= offset.left + w &&
+            y >= offset.top && y <= offset.top + h) {
+            cut();
+        }
+    }
+});
 
 function addHeart(){
     $("#life").empty();


### PR DESCRIPTION
## Summary
- allow slicing with touchstart on fruit
- detect pointer or touch movement across the container
- fall back to touch coordinates when `event.pageX/Y` aren't available

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855cbdee4bc83219bfc845c61fa0726