### PR TITLE
Add accuracy-based difficulty scaler

### DIFF
--- a/jquery.js
+++ b/jquery.js
@@ -4,6 +4,11 @@ var lives;
 var dropSpeed=1;
 var action;
 var highScore=0;
+var hits = 0;
+var totalSlices = 0;
+var difficulty = 1;
+var baseSpeed = 1;
+var baseDelay = 800;
 
 var fruits = ['apple', 'banana', 'grapes', 'mango', 'orange', 'peach', 'pear', 'pineapple','tomato','watermelon'];
 
@@ -62,35 +67,30 @@ function addHeart(){
     }
 }
 
-function startFruits(){
-    chooseFruit();
-    $("#fruit").css({'left' : Math.round(($("#container").width()-350)*Math.random())+200, 'top' : -50});
-    $("#fruit").css({'display':'flex'});
-    if(dropSpeed<=13){
-        dropSpeed+=1;
+function spawnNextFruit(){
+    totalSlices++;
+    if(totalSlices > 0 && hits / totalSlices > 0.9){
+        difficulty += 0.1;
     }
-    console.log("dropSpeed", dropSpeed)
+    dropSpeed = baseSpeed * difficulty;
+    chooseFruit();
+    $("#fruit").css({"left" : Math.round(($("#container").width()-350)*Math.random())+200, "top" : -50});
+    $("#fruit").css({"display":"flex"});
+}
+function startFruits(){
+    spawnNextFruit();
     action = setInterval(function(){
-        
-        $("#fruit").css('top', $("#fruit").position().top + dropSpeed);
+        $("#fruit").css("top", $("#fruit").position().top + dropSpeed);
         if($("#fruit").position().top > $("#container").height()){
-            
             if(lives > 1 ){
-                
-                $("#fruit").css({'display':'flex'});
-                chooseFruit();
-                $("#fruit").css({'left' : Math.round(($("#container").width()-350)*Math.random())+200, 'top' : -50});
-                
+                spawnNextFruit();
                 lives-=1;
-                
                 addHeart();
-                
-            }else{ 
-                playing = false;
-                $("#liferem").css('display','none');
+            }else{
+                isPlaying = false;
+                $("#liferem").css("display","none");
                 $("#fsc").text(score);
                 lives-=1;
-                
                 addHeart();
                 $("#endgame").show();
                 stopAction();
@@ -98,6 +98,7 @@ function startFruits(){
         }
     },10)
 }
+
 
 function chooseFruit(){
     $("#fruit").attr('src' , 'images/' + fruits[Math.round(9*Math.random())] +'.png');
@@ -114,11 +115,12 @@ function stopAction(){
 
 function cut(){
     score++;
+    hits++;
     $("#value").html(score);
     $("#slicesound")[0].play();
     $("#fruit").hide("explode", 500); 
     $("#fruit").css({'display':'flex'});
     clearInterval(action);
     
-    setTimeout(startFruits, 800);
+    setTimeout(startFruits, baseDelay / difficulty);
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "fruit-ninja",
+  "version": "1.0.0",
+  "description": "Fruit Ninja game using HTML, CSS and JavaScript",
+  "scripts": {
+    "start": "http-server -p 8080",
+    "test": "echo \"No test specified\" && exit 1"
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add variables to track slice accuracy and difficulty
- introduce `spawnNextFruit` and update `startFruits` for dynamic speed
- adjust cut handling to update accuracy and spawn delay
- add `package.json` with start/test scripts

## Testing
- `npm test` *(fails: No test specified)*
- `npm install` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6855cc5b0ef483219051c044c719be72