### PR TITLE
Add http-server dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "lint": "echo \"No lint step\"",
     "build": "echo \"No build step\""
   },
-  "dependencies": {},
+  "dependencies": {
+    "http-server": "^14.1.1"
+  },
   "devDependencies": {}
 }


### PR DESCRIPTION
## Summary
- add the `http-server` package to dependencies so running a static server is possible
- keep the `start` script pointing to `server.js`

## Testing
- `npm test` *(fails: No test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68588f36a938832181060e28a179250a