### PR TITLE
Remove invalid build step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,4 +11,4 @@ jobs:
         node-version: 18
     - run: npm install
     - run: npm run lint
-    - run: npm run build
+    # - run: npm run build


### PR DESCRIPTION
## Summary
- comment out `npm run build` in CI workflow since there is no build script

## Testing
- `npm test` *(fails: No test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68588f565f3c8321a93db4be25652d91