### PR TITLE
Add canvas-based fruit slicing loop

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,133 +1,155 @@
-// Basic Fruit Ninja style game implementation using HTML5 Canvas
-// Handles fruit spawning, slicing detection and score keeping
+'use strict';
 
-window.onload = function () {
-  const container = document.getElementById("container");
-  const scoreEl = document.getElementById("value");
-  const startBtn = document.getElementById("start");
-  const sliceSound = document.getElementById("slicesound");
+// Fruit Ninja style mini game implemented with HTML5 Canvas.
+// Handles fruit creation, slicing interaction and scoring.
 
-  let canvas, ctx;
+window.addEventListener('load', function () {
+  const container = document.getElementById('container');
+  const scoreEl = document.getElementById('value');
+  const startBtn = document.getElementById('start');
+  const restartBtn = document.getElementById('restartGame');
+  const backBtn = document.getElementById('restart');
+  const endScreen = document.getElementById('endgame');
+  const finalScoreEl = document.getElementById('fsc');
+  const sliceSound = document.getElementById('slicesound');
+
+  let canvas;
+  let ctx;
   let running = false;
   let fruits = [];
   let lastSpawn = 0;
-  let score = 0;
   let lastTime = 0;
-  const spawnDelay = 1000; // time between spawns in ms
+  let score = 0;
+
+  const spawnInterval = 1000; // ms between fruit spawns
   const gravity = 0.35;
 
   const fruitImages = [
-    "apple.png",
-    "banana.png",
-    "grapes.png",
-    "mango.png",
-    "orange.png",
-    "peach.png",
+    'apple.png',
+    'banana.png',
+    'grapes.png',
+    'mango.png',
+    'orange.png',
+    'peach.png',
+    'pear.png',
+    'pineapple.png',
+    'tomato.png',
+    'watermelon.png',
   ];
 
-  function initCanvas() {
-    canvas = document.createElement("canvas");
+  function setupCanvas() {
+    if (!canvas) {
+      canvas = document.createElement('canvas');
+      container.appendChild(canvas);
+      ctx = canvas.getContext('2d');
+      canvas.addEventListener('mousemove', handlePointer);
+      canvas.addEventListener('touchmove', handleTouch, { passive: false });
+    }
     canvas.width = container.clientWidth;
     canvas.height = container.clientHeight;
-    container.appendChild(canvas);
-    ctx = canvas.getContext("2d");
-
-    canvas.addEventListener("mousemove", handleMove);
-    canvas.addEventListener("touchmove", (e) => {
-      const t = e.touches[0];
-      handleMove({ offsetX: t.clientX, offsetY: t.clientY, preventDefault: () => {} });
-    });
   }
 
-  let pointer = { x: 0, y: 0, prevX: 0, prevY: 0 };
+  const pointer = { x: 0, y: 0, prevX: 0, prevY: 0 };
 
-  function handleMove(e) {
-    e.preventDefault();
+  function handlePointer(e) {
     pointer.prevX = pointer.x;
     pointer.prevY = pointer.y;
     pointer.x = e.offsetX;
     pointer.y = e.offsetY;
   }
 
+  function handleTouch(e) {
+    e.preventDefault();
+    const rect = canvas.getBoundingClientRect();
+    const touch = e.touches[0];
+    handlePointer({
+      offsetX: touch.clientX - rect.left,
+      offsetY: touch.clientY - rect.top,
+    });
+  }
+
   function spawnFruit() {
     const img = new Image();
-    // randomly pick an image for the fruit
-    img.src =
-      "images/" + fruitImages[Math.floor(Math.random() * fruitImages.length)];
+    img.src = 'images/' +
+      fruitImages[Math.floor(Math.random() * fruitImages.length)];
     const radius = 30;
-    const x = Math.random() * (canvas.width - radius * 2) + radius;
+    const x = radius + Math.random() * (canvas.width - radius * 2);
     const y = canvas.height + radius;
     const vx = (Math.random() - 0.5) * 4;
-    const vy = -8 - Math.random() * 4;
+    const vy = -9 - Math.random() * 4;
     fruits.push({ x, y, vx, vy, r: radius, img, sliced: false });
   }
 
-  function updateFruits(dt) {
-    for (const fruit of fruits) {
-      fruit.vy += gravity;
-      fruit.x += fruit.vx;
-      fruit.y += fruit.vy;
+  function update(dt) {
+    for (const f of fruits) {
+      f.vy += gravity;
+      f.x += f.vx;
+      f.y += f.vy;
 
-      // simple line-circle intersection for slicing
-      const dx = fruit.x - pointer.x;
-      const dy = fruit.y - pointer.y;
-      const dist = Math.sqrt(dx * dx + dy * dy);
-      if (!fruit.sliced && dist < fruit.r) {
-        fruit.sliced = true;
-        score++;
+      const dx = f.x - pointer.x;
+      const dy = f.y - pointer.y;
+      if (!f.sliced && Math.hypot(dx, dy) <= f.r) {
+        f.sliced = true;
+        score += 1;
         scoreEl.textContent = score;
         sliceSound.currentTime = 0;
         sliceSound.play();
       }
     }
-    // remove fruits out of screen or sliced
     fruits = fruits.filter((f) => !f.sliced && f.y - f.r < canvas.height);
   }
 
-  function drawFruits() {
-    for (const fruit of fruits) {
-      ctx.drawImage(fruit.img, fruit.x - fruit.r, fruit.y - fruit.r, fruit.r * 2, fruit.r * 2);
+  function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    for (const f of fruits) {
+      ctx.drawImage(f.img, f.x - f.r, f.y - f.r, f.r * 2, f.r * 2);
     }
   }
 
-  function gameLoop(time) {
+  function loop(time) {
     if (!running) return;
     const dt = time - lastTime;
     lastTime = time;
 
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-    if (time - lastSpawn > spawnDelay) {
+    if (time - lastSpawn > spawnInterval) {
       spawnFruit();
       lastSpawn = time;
     }
 
-    updateFruits(dt);
-    drawFruits();
+    update(dt);
+    draw();
 
-    requestAnimationFrame(gameLoop);
+    requestAnimationFrame(loop);
   }
 
   function startGame() {
-    // show container before measuring dimensions
-    container.style.display = "flex";
-    if (!canvas) {
-      initCanvas();
-    } else {
-      canvas.width = container.clientWidth;
-      canvas.height = container.clientHeight;
-    }
+    container.style.display = 'flex';
+    endScreen.style.display = 'none';
+    setupCanvas();
     score = 0;
     scoreEl.textContent = score;
     fruits = [];
     running = true;
     lastTime = performance.now();
     lastSpawn = lastTime;
-    requestAnimationFrame(gameLoop);
+    requestAnimationFrame(loop);
   }
 
-  startBtn.addEventListener("click", () => {
-    document.getElementById("menubar").style.display = "none";
+  function endGame() {
+    running = false;
+    finalScoreEl.textContent = score;
+    endScreen.style.display = 'block';
+  }
+
+  startBtn.addEventListener('click', () => {
+    document.getElementById('menubar').style.display = 'none';
     startGame();
   });
-};
+
+  restartBtn.addEventListener('click', startGame);
+  backBtn.addEventListener('click', () => window.location.reload());
+
+  // For now we never automatically end the game. In a real game you could
+  // decrease lives when fruits fall off screen and call endGame when lives
+  // reach zero.
+});

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -51,7 +51,9 @@ window.onload = function () {
 
   function spawnFruit() {
     const img = new Image();
-    img.src = "images/" + fruitImages[Math.floor(Math.random() * fruitImages.length)];
+    // randomly pick an image for the fruit
+    img.src =
+      "images/" + fruitImages[Math.floor(Math.random() * fruitImages.length)];
     const radius = 30;
     const x = Math.random() * (canvas.width - radius * 2) + radius;
     const y = canvas.height + radius;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -51,7 +51,8 @@ window.onload = function () {
 
   function spawnFruit() {
     const img = new Image();
-    img.src = "images/" + fruitImages[Math.floor(Math.random() * fruitImages.length)];
+    img.src =
+      "images/" + fruitImages[Math.floor(Math.random() * fruitImages.length)];
     const radius = 30;
     const x = Math.random() * (canvas.width - radius * 2) + radius;
     const y = canvas.height + radius;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -51,8 +51,7 @@ window.onload = function () {
 
   function spawnFruit() {
     const img = new Image();
-    img.src =
-      "images/" + fruitImages[Math.floor(Math.random() * fruitImages.length)];
+    img.src = "images/" + fruitImages[Math.floor(Math.random() * fruitImages.length)];
     const radius = 30;
     const x = Math.random() * (canvas.width - radius * 2) + radius;
     const y = canvas.height + radius;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -109,10 +109,14 @@ window.onload = function () {
   }
 
   function startGame() {
+    // show container before measuring dimensions
+    container.style.display = "flex";
     if (!canvas) {
       initCanvas();
+    } else {
+      canvas.width = container.clientWidth;
+      canvas.height = container.clientHeight;
     }
-    container.style.display = "flex";
     score = 0;
     scoreEl.textContent = score;
     fruits = [];

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,7 +1,127 @@
-// Placeholder for extracted inline scripts
+// Basic Fruit Ninja style game implementation using HTML5 Canvas
+// Handles fruit spawning, slicing detection and score keeping
 
-// Basic game logic initialization
 window.onload = function () {
-  console.log("Game initialized");
-  // TODO: Setup canvas, fruit spawning, collision detection
+  const container = document.getElementById("container");
+  const scoreEl = document.getElementById("value");
+  const startBtn = document.getElementById("start");
+  const sliceSound = document.getElementById("slicesound");
+
+  let canvas, ctx;
+  let running = false;
+  let fruits = [];
+  let lastSpawn = 0;
+  let score = 0;
+  let lastTime = 0;
+  const spawnDelay = 1000; // time between spawns in ms
+  const gravity = 0.35;
+
+  const fruitImages = [
+    "apple.png",
+    "banana.png",
+    "grapes.png",
+    "mango.png",
+    "orange.png",
+    "peach.png",
+  ];
+
+  function initCanvas() {
+    canvas = document.createElement("canvas");
+    canvas.width = container.clientWidth;
+    canvas.height = container.clientHeight;
+    container.appendChild(canvas);
+    ctx = canvas.getContext("2d");
+
+    canvas.addEventListener("mousemove", handleMove);
+    canvas.addEventListener("touchmove", (e) => {
+      const t = e.touches[0];
+      handleMove({ offsetX: t.clientX, offsetY: t.clientY, preventDefault: () => {} });
+    });
+  }
+
+  let pointer = { x: 0, y: 0, prevX: 0, prevY: 0 };
+
+  function handleMove(e) {
+    e.preventDefault();
+    pointer.prevX = pointer.x;
+    pointer.prevY = pointer.y;
+    pointer.x = e.offsetX;
+    pointer.y = e.offsetY;
+  }
+
+  function spawnFruit() {
+    const img = new Image();
+    img.src = "images/" + fruitImages[Math.floor(Math.random() * fruitImages.length)];
+    const radius = 30;
+    const x = Math.random() * (canvas.width - radius * 2) + radius;
+    const y = canvas.height + radius;
+    const vx = (Math.random() - 0.5) * 4;
+    const vy = -8 - Math.random() * 4;
+    fruits.push({ x, y, vx, vy, r: radius, img, sliced: false });
+  }
+
+  function updateFruits(dt) {
+    for (const fruit of fruits) {
+      fruit.vy += gravity;
+      fruit.x += fruit.vx;
+      fruit.y += fruit.vy;
+
+      // simple line-circle intersection for slicing
+      const dx = fruit.x - pointer.x;
+      const dy = fruit.y - pointer.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (!fruit.sliced && dist < fruit.r) {
+        fruit.sliced = true;
+        score++;
+        scoreEl.textContent = score;
+        sliceSound.currentTime = 0;
+        sliceSound.play();
+      }
+    }
+    // remove fruits out of screen or sliced
+    fruits = fruits.filter((f) => !f.sliced && f.y - f.r < canvas.height);
+  }
+
+  function drawFruits() {
+    for (const fruit of fruits) {
+      ctx.drawImage(fruit.img, fruit.x - fruit.r, fruit.y - fruit.r, fruit.r * 2, fruit.r * 2);
+    }
+  }
+
+  function gameLoop(time) {
+    if (!running) return;
+    const dt = time - lastTime;
+    lastTime = time;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    if (time - lastSpawn > spawnDelay) {
+      spawnFruit();
+      lastSpawn = time;
+    }
+
+    updateFruits(dt);
+    drawFruits();
+
+    requestAnimationFrame(gameLoop);
+  }
+
+  function startGame() {
+    if (!canvas) {
+      initCanvas();
+    }
+    container.style.display = "flex";
+    score = 0;
+    scoreEl.textContent = score;
+    fruits = [];
+    running = true;
+    lastTime = performance.now();
+    lastSpawn = lastTime;
+    requestAnimationFrame(gameLoop);
+  }
+
+  startBtn.addEventListener("click", () => {
+    document.getElementById("menubar").style.display = "none";
+    startGame();
+  });
 };


### PR DESCRIPTION
## Summary
- implement Fruit Ninja style canvas loop in `scripts/main.js`
- spawn fruits, detect slicing collisions and track score

## Testing
- `npm test` *(fails: No test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685893ee6cf883218c024a91d56a6b74