### PR TITLE
Ensure npm scripts work offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Scores can be saved to Firebase when configured.
    cd Fruit-Ninja-Clean
    ```
 
-2. Install dependencies for the optional server
+2. (Optional) Install dependencies if you plan to add any later
 
    ```bash
    npm install
@@ -47,6 +47,8 @@ Launch the provided HTTP server with:
 
 ```bash
 npm start
+# or
+npm run dev
 ```
 
 This runs `node server.js` and serves the game at `http://localhost:8080/`.

--- a/package.json
+++ b/package.json
@@ -4,12 +4,11 @@
   "description": "Fruit Ninja game using HTML, CSS and JavaScript",
   "scripts": {
     "start": "node server.js",
+    "dev": "node server.js",
     "test": "echo \"No test specified\" && exit 1",
     "lint": "echo \"No lint step\"",
     "build": "echo \"No build step\""
   },
-  "dependencies": {
-    "http-server": "^14.1.1"
-  },
+  "dependencies": {},
   "devDependencies": {}
 }


### PR DESCRIPTION
## Summary
- remove unused `http-server` dependency
- allow `npm run dev` as an alias for starting the server
- document optional dependency installation and `npm run dev`

## Testing
- `npm run lint`
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68589ae5036c83219b66cfbc065ee32f