### PR TITLE
Fix repo placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Scores can be saved to Firebase when configured.
 1. Clone the repository
 
    ```bash
-   git clone <repo>
+   git clone <repository-url>
    cd Fruit-Ninja-Clean
    ```
 


### PR DESCRIPTION
## Summary
- update repo URL placeholder in README

## Testing
- `npm test` *(fails: No test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858a35a44388321b06e717132e09e18