### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,6 +2,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -13,23 +14,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: .
   deploy:
-    needs: build
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./
+      - id: deployment
         uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ For a static deployment, host all the files on any web server. Make sure
 On a Node-capable host, copy the repository and run `node server.js`. Set the
 `PORT` environment variable if you need the server to listen on a different port.
 
+### GitHub Pages
+
+This repository contains a workflow that automatically publishes the game to
+GitHub Pages whenever changes are pushed to the `main` branch. To enable it,
+open your repository's settings, activate GitHub Pages and select the
+"GitHub Actions" source. The site will then be available at
+`https://<username>.github.io/<repository>` after each push.
+
 ## Customization
 
 Color variables and dark-mode styles are defined at the top of `styling.css`.

--- a/README.md
+++ b/README.md
@@ -79,11 +79,12 @@ On a Node-capable host, copy the repository and run `node server.js`. Set the
 
 ### GitHub Pages
 
-This repository contains a workflow that automatically publishes the game to
-GitHub Pages whenever changes are pushed to the `main` branch. To enable it,
-open your repository's settings, activate GitHub Pages and select the
-"GitHub Actions" source. The site will then be available at
-`https://<username>.github.io/<repository>` after each push.
+This repository includes a GitHub Actions workflow that publishes the game to
+GitHub Pages. It runs automatically on every push to the `main` branch or when
+manually triggered from the Actions tab. To enable it, open your repository's
+settings, activate GitHub Pages and select the "GitHub Actions" source. After
+each run the site will be available at
+`https://<username>.github.io/<repository>`.
 
 ## Customization
 


### PR DESCRIPTION
## Summary
- document GitHub Pages deployment in the README
- add a GitHub Actions workflow that publishes to GitHub Pages

## Testing
- `npm test` *(fails: No test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858a6d352508321923d937ef77ed64f